### PR TITLE
Update Ledger Nano Device IDs (So it works with Ledger RVN app 1.5.1+)

### DIFF
--- a/contrib/requirements/requirements-hw.txt
+++ b/contrib/requirements/requirements-hw.txt
@@ -1,4 +1,4 @@
-trezor[hidapi]>=0.11.0
+trezor[hidapi]==0.11.6
 safet[hidapi]>=0.1.0
 keepkey>=6.0.3
 btchip-python>=0.1.26

--- a/electrum/plugins/ledger/ledger.py
+++ b/electrum/plugins/ledger/ledger.py
@@ -558,8 +558,14 @@ class LedgerPlugin(HW_PluginBase):
                    (0x2581, 0x3b7c), # HW.1 ledger production
                    (0x2581, 0x4b7c), # HW.1 ledger test
                    (0x2c97, 0x0000), # Blue
+                   (0x2c97, 0x0011), # Blue app-bitcoin >= 1.5.1
+                   (0x2c97, 0x0015), # Blue app-bitcoin >= 1.5.1
                    (0x2c97, 0x0001), # Nano-S
+                   (0x2c97, 0x1011), # Nano-S app-bitcoin >= 1.5.1
+                   (0x2c97, 0x1015), # Nano-S app-bitcoin >= 1.5.1
                    (0x2c97, 0x0004), # Nano-X
+                   (0x2c97, 0x4011), # Nano-X app-bitcoin >= 1.5.1
+                   (0x2c97, 0x4015), # Nano-X app-bitcoin >= 1.5.1
                    (0x2c97, 0x0005), # RFU
                    (0x2c97, 0x0006), # RFU
                    (0x2c97, 0x0007), # RFU


### PR DESCRIPTION
See
https://www.ledger.com/windows-10-update-sunsetting-u2f-tunnel-transport-for-ledger-devices/